### PR TITLE
README.md: Use go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ##### Compile from Source
 
-    $ go get -u github.com/ddollar/forego
+    $ go install github.com/ddollar/forego@latest
 
 ### Usage
 


### PR DESCRIPTION
The previous approach doesn't seem to work on recent Go versions any more.